### PR TITLE
Configure CI for Commitizen bump and versioning updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ on:
       - 'tests/**'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   publish:
     name: 'Publish on PyPi'
@@ -41,11 +44,22 @@ jobs:
       - name: Bump version with Commitizen
         if: steps.check.outputs.skip == 'false'
         run: cz bump --yes
+      - name: Push bumped version back to repository
+        if: steps.check.outputs.skip == 'false'
+        run: |
+          branch=${GITHUB_REF#refs/heads/}
+          git push origin HEAD:$branch --follow-tags
+      - name: Clean previous build artifacts
+        if: steps.check.outputs.skip == 'false'
+        run: rm -rf dist
       - name: Build package
+        if: steps.check.outputs.skip == 'false'
         run: python -m build
       - name: Check package
+        if: steps.check.outputs.skip == 'false'
         run: twine check dist/*
       - name: Publish
+        if: steps.check.outputs.skip == 'false'
         run: |
           if [[ $GITHUB_REF == refs/heads/main ]]; then
             echo "Deploying to production environment"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,10 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Configure Git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,5 +29,6 @@ pythonpath = [
 
 [tool.commitizen]
 name = "cz_conventional_commits"
+version_provider = "pep621"
 tag_format = "v$version"
 version_files = ["pyproject.toml"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyjeb"
-version = "1.0.5"
+version = "1.1.0"
 description = "A powerfull lightweight library to check and variabilize your configuration files"
 authors = [{name = "CSharplie"}]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,5 @@ pythonpath = [
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "1.1.0"
 tag_format = "v$version"
 version_files = ["pyproject.toml"]


### PR DESCRIPTION
# PR: Configure CI for Commitizen bump and versioning updates

## Summary

This PR standardizes versioning and release automation by making `pyproject.toml` the single source of truth and fixing the GitHub Actions release workflow.

## Changes

- `pyproject.toml`
  - Centralized package metadata in PEP 621 format
  - Added `version_provider = "pep621"` for Commitizen
  - Kept `version_files = ["pyproject.toml"]` so `cz bump` updates the project version

- `.github/workflows/release.yml`
  - Added `permissions: contents: write`
  - Configured Git identity for CI-generated bump commits
  - Pushed bump commits back to the branch with tags
  - Prevented build/publish on auto-generated bump commits
  - Cleaned old `dist` artifacts before building

## Why

- Commitizen now reads and writes version directly from `project.version`
- Prevents duplicate PyPI/TestPyPI publishes from repeated bump-triggered workflow runs
- Ensures `python -m build` uses the same version that Commitizen manages
