### PR TITLE
Enhance documentation structure and sync with wiki

### DIFF
--- a/.github/workflows/sync_wiki.yml
+++ b/.github/workflows/sync_wiki.yml
@@ -1,0 +1,44 @@
+name: 'Sync docs to Wiki'
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    name: 'Sync docs folder to Wiki'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Checkout wiki
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ github.repository }}.wiki
+          path: wiki
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sync docs to wiki
+        run: |
+          rsync -av --delete --exclude='.git/' docs/ wiki/
+
+      - name: Commit and push wiki changes
+        run: |
+          cd wiki
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "docs: sync from main repository"
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -1,102 +1,73 @@
-# Pyjeb
+# PyJeb
 
-PyJeb is a powerfull lightweight library to check and variabilize your configuration files.
-The main features of pyjeb are:
+PyJeb is a lightweight Python library to validate and variabilize your configuration files.
 
-* Control the structure of a configuration file (missing value, type, format, valid set)
-* Add default value for missing fields
-* Setup variable values (system or user defined)
-* Allow case insensitive parameters
-* Allow to add executable functions in configuration
+- Validate configuration structure: required fields, types, format, allowed values
+- Set default values for optional fields
+- Inject dynamic values: system variables, user variables, custom functions
+- Case-insensitive parameter matching
+- Expose configuration as an attribute-accessible Python object
 
-# Get started
-## Steps
-1. Install PyJeb package
-2. Setup [control file](https://github.com/CSharplie/pyjeb/wiki/controls-configuration)
-3. Setup configuration file
-4. Call [control_and_setup](https://github.com/CSharplie/pyjeb/wiki/control_and_setup) function
+## Installation
 
-## Install PyJeb
-Install from [PyPi](https://pypi.org/project/pyjeb/) package manager:
-``` shell
+```shell
 pip install pyjeb
 ```
 
-## Exemple
-Setup a configuration file for your script.
+## Quick example
 
-In this exemple a yaml file will be used, but JSON can also be used.
+_job.yaml_
+```yaml
+ingest_customers:
+  source:
+    path: "/landing/$var.env/customers/$sys.timestamp('YYYY-MM-DD')"
+    format: "csv"
+  target:
+    path: "/bronze/$var.env/customers"
 
-_Exemple of yaml configuration file - configuration.yaml_
-``` yaml
-HR - Employees:
+ingest_orders:
   source:
-    path: "/Landing/HR/Employees/$sys.timestamp('YYYY-MM-DD')"
-    pattern: "*.csv"
+    path: "/landing/$var.env/orders/$sys.timestamp('YYYY-MM-DD')"
+    format: "json"
   target:
-    path: "/Bronze/HR/Employees"
-HR - Managers:
-  source:
-    path: "/Landing/HR/Managers/$sys.timestamp('YYYY-MM-DD')"
-  target:
-    path: "/Bronze/HR/Managers"
-HR - Payroll:
-  source:
-    path: "/Landing/HR/Payroll/$sys.timestamp('YYYY-MM-DD')"
-  target:
-    path: "/Bronze/HR/Payroll"
+    path: "/bronze/$var.env/orders"
 ```
 
-Setup a configuration to describe the previous configuration file and add default value for non mendatory field
-
-_Exemple of yaml configuration file - control.yaml_
-``` python
-control = [
-  { "name": "source", "type": "dict" },
-  { "name": "source.path" },
-  { "name": "source.pattern", "default": "*" },
-  { "name": "target", "type": "dict" },
-  { "name": "target.path" },
-]
-```
-
-Load the configuration and apply function _control_and_setup_ function with control parameters.
-
-This function will:
-- Setup default if the value is not defined
-- Setup value of variable ($sys.timestamp in this exemple)
-- Set configuration as object (callable with dots)
-
-``` python
+```python
 import yaml
 from pyjeb import control_and_setup
 
-# load configuration file
-with open("configuration.yaml") as f:
-  configuration = yaml.load(f, Loader = yaml.loader.SafeLoader)
+with open("job.yaml") as f:
+    config = yaml.safe_load(f)
 
-# control configuration
-control = [
-  { "name": "source", "type": "dict" },
-  { "name": "source.path" },
-  { "name": "source.pattern", "default": "*" },
-  { "name": "target", "type": "dict" },
-  { "name": "target.path" },
+controls = [
+    { "name": "source", "type": "dict" },
+    { "name": "source.path" },
+    { "name": "source.format", "validset": ["csv", "json", "parquet"] },
+    { "name": "source.pattern", "default": "*" },
+    { "name": "target", "type": "dict" },
+    { "name": "target.path" },
+    { "name": "target.mode", "default": "append", "validset": ["append", "overwrite"] },
+    { "name": "enabled", "type": "boolean", "default": True },
+    { "name": "max_retries", "type": "integer", "default": 3 },
 ]
 
-# loop on each item in configuration
-for item in configuration:
-  item_configuration = configuration[item]
+variables = { "env": "prod" }
 
-  # apply the control and instantiate variables
-  item_configuration = control_and_setup(item_configuration, control, to_object = True)
-
-  # display values
-  print(f"--------------- {item}")
-  print(f"source.path = '{item_configuration.source.path}'")
-  print(f"source.pattern = '{item_configuration.source.pattern}'")
-  print(f"target.path = '{item_configuration.target.path}'")
+for job_name, job_config in config.items():
+    job = control_and_setup(job_config, controls, variables=variables, to_object=True)
+    print(f"{job_name}: {job.source.path} → {job.target.path}")
 ```
+
+Output (run on 2026-05-11):
+```
+ingest_customers: /landing/prod/customers/2026-05-11 → /bronze/prod/customers
+ingest_orders: /landing/prod/orders/2026-05-11 → /bronze/prod/orders
+```
+
+## Documentation
+
+Full documentation is available on the [GitHub wiki](https://github.com/CSharplie/pyjeb/wiki).
 
 _Output of the script_
 ``` ini

--- a/docs/Exceptions.md
+++ b/docs/Exceptions.md
@@ -1,0 +1,200 @@
+# Exceptions
+
+PyJeb raises typed exceptions when a configuration or control definition is invalid.
+
+All exceptions can be imported from `pyjeb.exception`:
+
+```python
+from pyjeb.exception import (
+    NotProvidedParameterException,
+    EmptyParameterException,
+    InvalidTypeParameterException,
+    InvalidValueParameterException,
+    InvalidControlException,
+    CustomFunctionException,
+)
+```
+
+## Exception hierarchy
+
+```
+Exception
+├── InvalidParameterException
+│   ├── NotProvidedParameterException
+│   ├── EmptyParameterException
+│   ├── InvalidTypeParameterException
+│   └── InvalidValueParameterException
+├── InvalidControlException
+└── CustomFunctionException
+```
+
+---
+
+## `NotProvidedParameterException`
+
+**Raised when**: a required field (no `default`) is absent from the configuration.
+
+```python
+controls = [
+    { "name": "source", "type": "dict" },
+    { "name": "source.path" },           # required — no default
+    { "name": "source.format", "validset": ["csv", "json", "parquet"] },
+    # ...
+]
+
+job_config = {
+    "source": { "format": "csv" },       # source.path is missing
+    "target": { "path": "/bronze/prod/customers" }
+}
+```
+
+```python
+from pyjeb.exception import NotProvidedParameterException
+
+try:
+    job = control_and_setup(job_config, controls)
+except NotProvidedParameterException as e:
+    print(e)
+# The property 'source.path' is not setup and have no default value
+```
+
+---
+
+## `EmptyParameterException`
+
+**Raised when**: a required field is present but its value is empty (`""` or `None`).
+
+```python
+job_config = {
+    "source": { "path": "", "format": "csv" },   # path is empty
+    "target": { "path": "/bronze/prod/customers" }
+}
+```
+
+```python
+from pyjeb.exception import EmptyParameterException
+
+try:
+    job = control_and_setup(job_config, controls)
+except EmptyParameterException as e:
+    print(e)
+# Property 'source.path' can't be empty
+```
+
+---
+
+## `InvalidTypeParameterException`
+
+**Raised when**: a field value does not match the declared type.
+
+```python
+job_config = {
+    "source": { "path": "/landing/prod/customers", "format": "csv" },
+    "target": { "path": "/bronze/prod/customers" },
+    "max_retries": "not-a-number"    # declared as integer
+}
+```
+
+```python
+from pyjeb.exception import InvalidTypeParameterException
+
+try:
+    job = control_and_setup(job_config, controls)
+except InvalidTypeParameterException as e:
+    print(e)
+# Property 'max_retries' has invalid value 'not-a-number' (type must be integer)
+```
+
+---
+
+## `InvalidValueParameterException`
+
+**Raised when**: a field value is not in the allowed `validset`, or does not match the `regex` pattern.
+
+```python
+job_config = {
+    "source": { "path": "/landing/prod/customers", "format": "xml" },  # not in validset
+    "target": { "path": "/bronze/prod/customers" }
+}
+```
+
+```python
+from pyjeb.exception import InvalidValueParameterException
+
+try:
+    job = control_and_setup(job_config, controls)
+except InvalidValueParameterException as e:
+    print(e)
+# Property 'source.format' ('csv', 'json', 'parquet') has invalid value 'xml'
+```
+
+---
+
+## `InvalidControlException`
+
+**Raised when**: a control definition is malformed. This includes invalid expression syntax or a field path referenced in an expression that cannot be resolved.
+
+```python
+controls_bad = [
+    { "name": "source", "type": "dict" },
+    { "name": "source.path" },
+    {
+        "name": "source.pattern",
+        "default": "*",
+        "expressions": ["if format EQUALS 'csv' return '*.csv'"]  # invalid syntax
+    },
+]
+```
+
+```python
+from pyjeb.exception import InvalidControlException
+
+try:
+    job = control_and_setup(job_config, controls_bad)
+except InvalidControlException as e:
+    print(e)
+```
+
+---
+
+## `CustomFunctionException`
+
+**Raised when**: a custom function registered in `functions` raises an exception during execution.
+
+```python
+functions = {
+    "get_bucket": lambda env: int(env)   # will fail if env is not a number
+}
+
+job_config = {
+    "source": { "path": "$func.get_bucket('prod')", "format": "csv" },
+    "target": { "path": "/bronze/prod/customers" }
+}
+```
+
+```python
+from pyjeb.exception import CustomFunctionException
+
+try:
+    job = control_and_setup(job_config, controls, functions=functions)
+except CustomFunctionException as e:
+    print(e)
+# Function 'func.get_bucket' raise an error with parameter 'prod'
+```
+
+---
+
+## Catching all PyJeb exceptions
+
+```python
+from pyjeb.exception import InvalidParameterException, InvalidControlException, CustomFunctionException
+
+try:
+    job = control_and_setup(job_config, controls, variables=variables)
+except InvalidParameterException as e:
+    print(f"Configuration error: {e}")
+except InvalidControlException as e:
+    print(f"Control definition error: {e}")
+except CustomFunctionException as e:
+    print(f"Custom function error: {e}")
+```

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -1,0 +1,135 @@
+# Getting Started
+
+This guide walks through a complete PyJeb setup using a data ingestion job configuration as a running example.
+
+## The scenario
+
+You manage a set of data ingestion jobs. Each job reads files from a source path and writes them to a target path, with operational parameters (format, retries, threshold, etc.). You want to:
+
+- Validate that required fields are present
+- Apply sensible defaults for optional fields
+- Inject the current date and environment name dynamically
+
+## Step 1 — Install PyJeb
+
+```shell
+pip install pyjeb
+```
+
+## Step 2 — Write the configuration file
+
+Create `job.yaml` with one or more job entries:
+
+```yaml
+# job.yaml
+ingest_customers:
+  source:
+    path: "/landing/$var.env/customers/$sys.timestamp('YYYY-MM-DD')"
+    format: "csv"
+    pattern: "*.csv"
+  target:
+    path: "/bronze/$var.env/customers"
+    mode: "append"
+  enabled: true
+  max_retries: 3
+  threshold: 0.95
+  tags:
+    - "crm"
+    - "daily"
+
+ingest_orders:
+  source:
+    path: "/landing/$var.env/orders/$sys.timestamp('YYYY-MM-DD')"
+    format: "json"
+  target:
+    path: "/bronze/$var.env/orders"
+  enabled: true
+```
+
+> `$var.env` and `$sys.timestamp(...)` are PyJeb variables resolved at runtime. See [Variables](variables/overview).
+
+## Step 3 — Define the control list
+
+The control list describes the expected structure of each job entry:
+
+```python
+controls = [
+    { "name": "source", "type": "dict" },
+    { "name": "source.path" },
+    { "name": "source.format", "validset": ["csv", "json", "parquet"] },
+    { "name": "source.pattern", "default": "*" },
+    { "name": "target", "type": "dict" },
+    { "name": "target.path" },
+    { "name": "target.mode", "default": "append", "validset": ["append", "overwrite"] },
+    { "name": "enabled", "type": "boolean", "default": True },
+    { "name": "max_retries", "type": "integer", "default": 3 },
+    { "name": "threshold", "type": "decimal", "default": 0.95 },
+    { "name": "tags", "type": "list", "default": [] },
+]
+```
+
+See [Controls — Overview](controls/overview) for all available control fields.
+
+## Step 4 — Apply control_and_setup
+
+```python
+import yaml
+from pyjeb import control_and_setup
+
+with open("job.yaml") as f:
+    config = yaml.safe_load(f)
+
+variables = { "env": "prod" }
+
+for job_name, job_config in config.items():
+    job = control_and_setup(job_config, controls, variables=variables, to_object=True)
+    print(f"[{job_name}]")
+    print(f"  source.path    = {job.source.path}")
+    print(f"  source.format  = {job.source.format}")
+    print(f"  source.pattern = {job.source.pattern}")
+    print(f"  target.path    = {job.target.path}")
+    print(f"  target.mode    = {job.target.mode}")
+    print(f"  enabled        = {job.enabled}")
+    print(f"  max_retries    = {job.max_retries}")
+    print(f"  threshold      = {job.threshold}")
+    print(f"  tags           = {job.tags}")
+```
+
+**Output** (run on 2026-05-11 with `env = "prod"`):
+
+```
+[ingest_customers]
+  source.path    = /landing/prod/customers/2026-05-11
+  source.format  = csv
+  source.pattern = *.csv
+  target.path    = /bronze/prod/customers
+  target.mode    = append
+  enabled        = True
+  max_retries    = 3
+  threshold      = 0.95
+  tags           = ['crm', 'daily']
+
+[ingest_orders]
+  source.path    = /landing/prod/orders/2026-05-11
+  source.format  = json
+  source.pattern = *
+  target.path    = /bronze/prod/orders
+  target.mode    = append
+  enabled        = True
+  max_retries    = 3
+  threshold      = 0.95
+  tags           = []
+```
+
+Notice that for `ingest_orders`:
+- `source.pattern` defaulted to `"*"` — not provided in the file
+- `target.mode` defaulted to `"append"` — not provided in the file
+- `enabled`, `max_retries`, `threshold`, `tags` all received their default values
+- `$var.env` was replaced by `"prod"`
+- `$sys.timestamp('YYYY-MM-DD')` was replaced by the current date
+
+## Next steps
+
+- Customize your control definitions: [Controls — Overview](controls/overview)
+- Use variables and functions: [Variables — Overview](variables/overview)
+- Handle validation errors: [Exceptions](exceptions)

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -1,0 +1,75 @@
+# PyJeb
+
+PyJeb is a lightweight Python library to validate and variabilize configuration files.
+
+It lets you define a **control schema** describing the expected structure of any YAML or JSON configuration, then applies it to validate values, inject defaults, and resolve variables — all in one call.
+
+## Features
+
+- Validate configuration structure: required fields, types, format, allowed values
+- Set default values for optional fields
+- Inject dynamic values: system variables, user variables, custom functions
+- Case-insensitive parameter matching
+- Expose configuration as an attribute-accessible Python object
+
+## Installation
+
+```shell
+pip install pyjeb
+```
+
+## How it works
+
+1. Write your **configuration file** (YAML or JSON)
+2. Define a **control list** describing expected fields
+3. Call [`control_and_setup`](api/Control-and-Setup)
+
+## Quick Example
+
+The following example validates and enriches data ingestion job configurations loaded from a YAML file.
+
+```python
+import yaml
+from pyjeb import control_and_setup
+
+with open("job.yaml") as f:
+    config = yaml.safe_load(f)
+
+controls = [
+    { "name": "source", "type": "dict" },
+    { "name": "source.path" },
+    { "name": "source.format", "validset": ["csv", "json", "parquet"] },
+    { "name": "source.pattern", "default": "*" },
+    { "name": "target", "type": "dict" },
+    { "name": "target.path" },
+    { "name": "target.mode", "default": "append", "validset": ["append", "overwrite"] },
+    { "name": "enabled", "type": "boolean", "default": True },
+    { "name": "max_retries", "type": "integer", "default": 3 },
+    { "name": "threshold", "type": "decimal", "default": 0.95 },
+    { "name": "tags", "type": "list", "default": [] },
+]
+
+variables = { "env": "prod" }
+
+for job_name, job_config in config.items():
+    job = control_and_setup(job_config, controls, variables=variables, to_object=True)
+    print(f"{job_name}: {job.source.path}")
+```
+
+## Documentation
+
+| Page | Description |
+|---|---|
+| [Getting Started](getting-started) | Step-by-step guide with a full working example |
+| [control_and_setup](api/Control-and-Setup) | API reference for the main function |
+| [Controls — Overview](controls/overview) | All control fields and their purpose |
+| [Controls — Types](controls/types) | Supported types and type casting |
+| [Controls — Validset](controls/validset) | Restrict values to an allowed set |
+| [Controls — Regex](controls/regex) | Validate values against a regular expression |
+| [Controls — Expressions](controls/expressions) | Conditional value mapping with expressions |
+| [Controls — Conditional Controls](controls/conditional-controls) | Dynamic control rules with `if` blocks |
+| [Variables — Overview](variables/overview) | Introduction to the variable system |
+| [Variables — System](variables/sys-variables) | Built-in `$sys.timestamp` and `$sys.date` |
+| [Variables — User](variables/user-variables) | Custom `$var.<name>` variables |
+| [Variables — Functions](variables/custom-functions) | Custom `$func.<name>` functions |
+| [Exceptions](exceptions) | Error types and when they are raised |

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -1,0 +1,35 @@
+## PyJeb
+
+**[Home](Home)**
+
+**[Getting Started](getting-started)**
+
+---
+
+### API Reference
+
+- [control_and_setup](api/Control-and-Setup)
+
+---
+
+### Controls
+
+- [Overview](controls/overview)
+- [Types](controls/types)
+- [Validset](controls/validset)
+- [Regex](controls/regex)
+- [Expressions](controls/expressions)
+- [Conditional Controls](controls/conditional-controls)
+
+---
+
+### Variables
+
+- [Overview](variables/overview)
+- [System Variables ($sys)](variables/sys-variables)
+- [User Variables ($var)](variables/user-variables)
+- [Custom Functions ($func)](variables/custom-functions)
+
+---
+
+**[Exceptions](exceptions)**

--- a/docs/api/Control-and-Setup.md
+++ b/docs/api/Control-and-Setup.md
@@ -1,0 +1,188 @@
+# control_and_setup
+
+```python
+from pyjeb import control_and_setup
+```
+
+The main function of PyJeb. Validates a configuration dictionary against a control list, applies defaults, resolves variables, and optionally converts the result to an attribute-accessible object.
+
+## Signature
+
+```python
+def control_and_setup(
+    configuration: any,
+    controls: list,
+    variables: dict = None,
+    functions: dict = None,
+    to_object: bool = False,
+    ignore_consistency: bool = False
+) -> any
+```
+
+## Parameters
+
+### `configuration`
+
+**Type**: `dict` or `list` | **Required**: Yes
+
+The configuration data to validate and enrich. Typically loaded from a YAML or JSON file.
+
+```python
+job_config = {
+    "source": {
+        "path": "/landing/$var.env/customers/$sys.timestamp('YYYY-MM-DD')",
+        "format": "csv",
+        "pattern": "*.csv"
+    },
+    "target": {
+        "path": "/bronze/$var.env/customers",
+        "mode": "append"
+    },
+    "enabled": True,
+    "max_retries": 3,
+    "threshold": 0.95,
+    "tags": ["crm", "daily"]
+}
+```
+
+---
+
+### `controls`
+
+**Type**: `list[dict]` | **Required**: Yes
+
+A list of control definitions. Each entry describes one field: its name, expected type, default value, allowed values, etc.
+
+```python
+controls = [
+    { "name": "source", "type": "dict" },
+    { "name": "source.path" },
+    { "name": "source.format", "validset": ["csv", "json", "parquet"] },
+    { "name": "source.pattern", "default": "*" },
+    { "name": "target", "type": "dict" },
+    { "name": "target.path" },
+    { "name": "target.mode", "default": "append", "validset": ["append", "overwrite"] },
+    { "name": "enabled", "type": "boolean", "default": True },
+    { "name": "max_retries", "type": "integer", "default": 3 },
+    { "name": "threshold", "type": "decimal", "default": 0.95 },
+    { "name": "tags", "type": "list", "default": [] },
+]
+```
+
+See [Controls — Overview](../controls/overview) for all supported fields.
+
+---
+
+### `variables`
+
+**Type**: `dict` | **Default**: `None` (treated as `{}`)
+
+A dictionary of named values injected into configuration strings via `$var.<name>` placeholders.
+
+```python
+variables = { "env": "prod" }
+```
+
+A configuration value containing `"/landing/$var.env/customers"` resolves to `"/landing/prod/customers"`.
+
+See [Variables — User](../variables/user-variables).
+
+---
+
+### `functions`
+
+**Type**: `dict` | **Default**: `None` (treated as `{}`)
+
+A dictionary of named callables injected via `$func.<name>('argument')` placeholders.
+
+```python
+functions = {
+    "get_bucket": lambda env: f"s3://my-bucket-{env}"
+}
+```
+
+See [Variables — Functions](../variables/custom-functions).
+
+---
+
+### `to_object`
+
+**Type**: `bool` | **Default**: `False`
+
+When `True`, the returned configuration is converted to a Python object where fields are accessible via dot notation.
+
+```python
+# dict access (to_object=False, default)
+job["source"]["path"]
+
+# object access (to_object=True)
+job.source.path
+```
+
+---
+
+### `ignore_consistency`
+
+**Type**: `bool` | **Default**: `False`
+
+By default, PyJeb validates the control list itself before processing (checking that parent fields exist for nested paths, types are valid, etc.). Set to `True` to skip this check.
+
+> Use with caution. Inconsistent controls may produce unexpected results.
+
+---
+
+## Return value
+
+Returns the validated and enriched configuration — as a `dict` by default, or as an attribute-accessible object when `to_object=True`.
+
+---
+
+## Full example
+
+```python
+import yaml
+from pyjeb import control_and_setup
+
+with open("job.yaml") as f:
+    config = yaml.safe_load(f)
+
+controls = [
+    { "name": "source", "type": "dict" },
+    { "name": "source.path" },
+    { "name": "source.format", "validset": ["csv", "json", "parquet"] },
+    { "name": "source.pattern", "default": "*" },
+    { "name": "target", "type": "dict" },
+    { "name": "target.path" },
+    { "name": "target.mode", "default": "append", "validset": ["append", "overwrite"] },
+    { "name": "enabled", "type": "boolean", "default": True },
+    { "name": "max_retries", "type": "integer", "default": 3 },
+    { "name": "threshold", "type": "decimal", "default": 0.95 },
+    { "name": "tags", "type": "list", "default": [] },
+]
+
+variables = { "env": "prod" }
+
+for job_name, job_config in config.items():
+    job = control_and_setup(
+        job_config,
+        controls,
+        variables=variables,
+        to_object=True
+    )
+    print(f"{job_name}: {job.source.path} → {job.target.path}")
+```
+
+---
+
+## Errors
+
+| Exception | Cause |
+|---|---|
+| `NotProvidedParameterException` | A required field (no `default`) is missing |
+| `EmptyParameterException` | A field is present but empty |
+| `InvalidTypeParameterException` | A field value does not match the expected type |
+| `InvalidValueParameterException` | A field value is not in `validset` or fails `regex` |
+| `InvalidControlException` | A control definition is malformed |
+| `CustomFunctionException` | A custom function raised an exception |
+
+See [Exceptions](../exceptions) for details.

--- a/docs/controls/Conditional Controls.md
+++ b/docs/controls/Conditional Controls.md
@@ -1,0 +1,164 @@
+# Controls — Conditional Controls
+
+The `if` field allows a control's `default`, `type`, `validset`, or `regex` to change dynamically based on sibling field values. This is useful when the rules for a field depend on the value of another field.
+
+## Syntax
+
+```python
+{
+    "name": "field",
+    "if": [
+        {
+            "expression": "<left> <op> <right>",
+            "default": "...",      # optional
+            "type": "...",         # optional
+            "validset": [...],     # optional
+            "regex": "..."         # optional
+        }
+    ]
+}
+```
+
+Conditions are evaluated in order. The first matching condition applies its overrides to the control. The expression syntax uses the same operators as [Expressions](expressions): `==` (equal) and `<>` (not equal).
+
+---
+
+## Example: conditional default
+
+Provide a different default for `source.pattern` based on the file format:
+
+```python
+{
+    "name": "source.pattern",
+    "if": [
+        { "expression": "format == 'csv'",     "default": "*.csv" },
+        { "expression": "format == 'json'",    "default": "*.json" },
+        { "expression": "format == 'parquet'", "default": "*.parquet" }
+    ]
+}
+```
+
+Configuration:
+
+```yaml
+ingest_customers:
+  source:
+    path: "/landing/prod/customers/2026-05-11"
+    format: "csv"
+  target:
+    path: "/bronze/prod/customers"
+```
+
+Result: `source.pattern` defaults to `"*.csv"` because `format` is `"csv"`.
+
+---
+
+## Example: conditional validset
+
+Restrict `target.mode` to `"overwrite"` only when the format is `"parquet"`:
+
+```python
+{
+    "name": "target.mode",
+    "if": [
+        {
+            "expression": "source.format == 'parquet'",
+            "validset": ["overwrite"],
+            "default": "overwrite"
+        },
+        {
+            "expression": "source.format <> 'parquet'",
+            "validset": ["append", "overwrite"],
+            "default": "append"
+        }
+    ]
+}
+```
+
+---
+
+## Example: conditional type and regex
+
+```python
+{
+    "name": "max_retries",
+    "if": [
+        {
+            "expression": "enabled == 'true'",
+            "type": "integer",
+            "regex": r"^[1-9][0-9]*$"
+        },
+        {
+            "expression": "enabled == 'false'",
+            "type": "string",
+            "default": "0"
+        }
+    ]
+}
+```
+
+When `enabled` is `true`, `max_retries` must be a positive integer. When `enabled` is `false`, it defaults to `"0"` and is treated as a string.
+
+---
+
+## Full example
+
+```python
+import yaml
+from pyjeb import control_and_setup
+
+controls = [
+    { "name": "source", "type": "dict" },
+    { "name": "source.path" },
+    { "name": "source.format", "validset": ["csv", "json", "parquet"] },
+    {
+        "name": "source.pattern",
+        "if": [
+            { "expression": "format == 'csv'",     "default": "*.csv" },
+            { "expression": "format == 'json'",    "default": "*.json" },
+            { "expression": "format == 'parquet'", "default": "*.parquet" }
+        ]
+    },
+    { "name": "target", "type": "dict" },
+    { "name": "target.path" },
+    {
+        "name": "target.mode",
+        "if": [
+            {
+                "expression": "source.format == 'parquet'",
+                "validset": ["overwrite"],
+                "default": "overwrite"
+            },
+            {
+                "expression": "source.format <> 'parquet'",
+                "validset": ["append", "overwrite"],
+                "default": "append"
+            }
+        ]
+    },
+    { "name": "enabled", "type": "boolean", "default": True },
+    { "name": "max_retries", "type": "integer", "default": 3 },
+    { "name": "threshold", "type": "decimal", "default": 0.95 },
+    { "name": "tags", "type": "list", "default": [] },
+]
+
+job_config = {
+    "source": { "path": "/landing/prod/customers/2026-05-11", "format": "csv" },
+    "target": { "path": "/bronze/prod/customers" }
+}
+
+job = control_and_setup(job_config, controls, to_object=True)
+print(job.source.pattern)   # *.csv     (conditional default)
+print(job.target.mode)      # append    (conditional default for non-parquet)
+```
+
+---
+
+## Difference from `expressions`
+
+| Feature | `expressions` | `if` |
+|---|---|---|
+| Changes the **value** | Yes | No |
+| Changes the **control rules** (`default`, `type`, `validset`, `regex`) | No | Yes |
+
+Use `expressions` to override a field's resolved value. Use `if` to change which rules apply to a field.

--- a/docs/controls/Expressions.md
+++ b/docs/controls/Expressions.md
@@ -1,0 +1,137 @@
+# Controls — Expressions
+
+Expressions allow a field's value to be **overridden** based on the value of a sibling field. They are evaluated before type checking and validation.
+
+## Syntax
+
+```python
+{ "name": "field", "expressions": ["if <left> <op> <right> return <value>"] }
+```
+
+- `<left>` and `<right>`: a quoted string (`'value'`), `null`, or a sibling field path
+- `<op>`: `==` (equal) or `<>` (not equal)
+- `<value>`: a quoted string, `null`, or a sibling field path
+
+Multiple expressions are evaluated in order. The first match applies; subsequent expressions are skipped.
+
+---
+
+## Example: derive a value from a sibling field
+
+Automatically set `source.pattern` based on `source.format`:
+
+```python
+{
+    "name": "source.pattern",
+    "default": "*",
+    "expressions": [
+        "if source.format == 'csv' return '*.csv'",
+        "if source.format == 'json' return '*.json'",
+        "if source.format == 'parquet' return '*.parquet'"
+    ]
+}
+```
+
+Configuration:
+
+```yaml
+ingest_orders:
+  source:
+    path: "/landing/prod/orders/2026-05-11"
+    format: "json"
+  target:
+    path: "/bronze/prod/orders"
+```
+
+Result: even though `source.pattern` is not set in the file, it resolves to `"*.json"` because `source.format` is `"json"`.
+
+---
+
+## Example: override based on another field
+
+Override `target.mode` when the job is disabled:
+
+```python
+{
+    "name": "target.mode",
+    "default": "append",
+    "validset": ["append", "overwrite"],
+    "expressions": ["if enabled == 'false' return 'overwrite'"]
+}
+```
+
+---
+
+## Operators
+
+| Operator | Meaning |
+|---|---|
+| `==` | Equal |
+| `<>` | Not equal |
+
+---
+
+## Using sibling field paths as values
+
+The return value can itself be a sibling field path:
+
+```python
+{
+    "name": "target.path",
+    "expressions": ["if source.path == null return source.path"]
+}
+```
+
+---
+
+## Using `null`
+
+```python
+{
+    "name": "source.pattern",
+    "default": "*",
+    "expressions": ["if source.format == 'parquet' return null"]
+}
+```
+
+Returns `None` when `source.format` is `"parquet"`.
+
+---
+
+## Full example
+
+```python
+import yaml
+from pyjeb import control_and_setup
+
+controls = [
+    { "name": "source", "type": "dict" },
+    { "name": "source.path" },
+    { "name": "source.format", "validset": ["csv", "json", "parquet"] },
+    {
+        "name": "source.pattern",
+        "default": "*",
+        "expressions": [
+            "if source.format == 'csv' return '*.csv'",
+            "if source.format == 'json' return '*.json'",
+            "if source.format == 'parquet' return '*.parquet'"
+        ]
+    },
+    { "name": "target", "type": "dict" },
+    { "name": "target.path" },
+    { "name": "target.mode", "default": "append", "validset": ["append", "overwrite"] },
+    { "name": "enabled", "type": "boolean", "default": True },
+    { "name": "max_retries", "type": "integer", "default": 3 },
+    { "name": "threshold", "type": "decimal", "default": 0.95 },
+    { "name": "tags", "type": "list", "default": [] },
+]
+
+job_config = {
+    "source": { "path": "/landing/prod/orders/2026-05-11", "format": "json" },
+    "target": { "path": "/bronze/prod/orders" }
+}
+
+job = control_and_setup(job_config, controls, to_object=True)
+print(job.source.pattern)   # *.json  (derived from source.format)
+print(job.target.mode)      # append  (default)
+```

--- a/docs/controls/Overview.md
+++ b/docs/controls/Overview.md
@@ -1,0 +1,157 @@
+# Controls — Overview
+
+A **control** is a Python dictionary that describes one field of a configuration. The `controls` parameter of [`control_and_setup`](../api/Control-and-Setup) is a list of such dictionaries.
+
+## Control fields
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `name` | string | Yes | — | Dot-separated path to the field |
+| `type` | string | No | `"string"` | Expected type of the value |
+| `default` | any | No | — | Value to use when the field is absent |
+| `validset` | list | No | — | List of allowed values or regex patterns |
+| `regex` | string | No | — | Regex pattern the value must match |
+| `expressions` | list | No | `[]` | List of conditional value overrides |
+| `if` | list | No | `[]` | List of conditional control overrides |
+| `nocheck` | boolean | No | `False` | Skip validation for this field |
+
+---
+
+## `name`
+
+The dot-separated path to the target field. Nested fields use `parent.child` notation.
+
+```python
+{ "name": "source" }           # top-level field
+{ "name": "source.path" }      # nested field
+{ "name": "source.format" }    # sibling of source.path
+```
+
+Parent fields must be declared before their children, and must have type `"dict"` or `"list"`.
+
+---
+
+## `type`
+
+The expected type for the field value. Defaults to `"string"` when omitted.
+
+Supported values: `"string"`, `"integer"`, `"decimal"`, `"boolean"`, `"list"`, `"dict"`
+
+```python
+{ "name": "source", "type": "dict" }
+{ "name": "enabled", "type": "boolean", "default": True }
+{ "name": "max_retries", "type": "integer", "default": 3 }
+{ "name": "threshold", "type": "decimal", "default": 0.95 }
+{ "name": "tags", "type": "list", "default": [] }
+```
+
+See [Controls — Types](types) for casting rules and details.
+
+---
+
+## `default`
+
+The value to use when the field is absent from the configuration.
+
+```python
+{ "name": "source.pattern", "default": "*" }
+{ "name": "target.mode", "default": "append" }
+{ "name": "max_retries", "type": "integer", "default": 3 }
+{ "name": "tags", "type": "list", "default": [] }
+```
+
+If `default` is not set, the field is **required** — a `NotProvidedParameterException` is raised when it is missing.
+
+---
+
+## `validset`
+
+A list of allowed values. The field value must match one entry exactly, or match one entry as a regex pattern.
+
+```python
+{ "name": "source.format", "validset": ["csv", "json", "parquet"] }
+{ "name": "target.mode", "default": "append", "validset": ["append", "overwrite"] }
+```
+
+See [Controls — Validset](validset).
+
+---
+
+## `regex`
+
+A regex pattern the field value must match.
+
+```python
+{ "name": "source.path", "regex": r"^/[a-zA-Z0-9/_\$\.\-]+$" }
+```
+
+See [Controls — Regex](regex).
+
+---
+
+## `expressions`
+
+A list of conditional value expressions that can override the field value based on sibling field values.
+
+```python
+{
+    "name": "source.pattern",
+    "default": "*",
+    "expressions": [
+        "if source.format == 'csv' return '*.csv'",
+        "if source.format == 'json' return '*.json'",
+        "if source.format == 'parquet' return '*.parquet'"
+    ]
+}
+```
+
+See [Controls — Expressions](expressions).
+
+---
+
+## `if`
+
+Conditional overrides that change the `default`, `type`, `validset`, or `regex` of a control based on sibling values.
+
+```python
+{
+    "name": "source.pattern",
+    "if": [
+        { "expression": "format == 'csv'",     "default": "*.csv" },
+        { "expression": "format == 'json'",    "default": "*.json" },
+        { "expression": "format == 'parquet'", "default": "*.parquet" }
+    ]
+}
+```
+
+See [Controls — Conditional Controls](conditional-controls).
+
+---
+
+## `nocheck`
+
+When set to `True`, validation is entirely skipped for this field. The value is passed through as-is.
+
+```python
+{ "name": "metadata", "nocheck": True }
+```
+
+---
+
+## Complete example
+
+```python
+controls = [
+    { "name": "source", "type": "dict" },
+    { "name": "source.path" },
+    { "name": "source.format", "validset": ["csv", "json", "parquet"] },
+    { "name": "source.pattern", "default": "*" },
+    { "name": "target", "type": "dict" },
+    { "name": "target.path" },
+    { "name": "target.mode", "default": "append", "validset": ["append", "overwrite"] },
+    { "name": "enabled", "type": "boolean", "default": True },
+    { "name": "max_retries", "type": "integer", "default": 3 },
+    { "name": "threshold", "type": "decimal", "default": 0.95 },
+    { "name": "tags", "type": "list", "default": [] },
+]
+```

--- a/docs/controls/Regex.md
+++ b/docs/controls/Regex.md
@@ -1,0 +1,87 @@
+# Controls — Regex
+
+The `regex` field validates a configuration value against a regular expression. The value must match the pattern for the control to pass. If it does not match, an `InvalidValueParameterException` is raised.
+
+## Syntax
+
+```python
+{ "name": "source.path", "regex": r"^/[a-zA-Z0-9/_\$\.\-]+$" }
+```
+
+---
+
+## Example
+
+Validate that `source.path` starts with `/` and contains only valid path characters:
+
+```python
+{ "name": "source.path", "regex": r"^/[a-zA-Z0-9/_\$\.\-]+$" }
+```
+
+**Valid**:
+
+```yaml
+source:
+  path: "/landing/prod/customers/2026-05-11"   # OK
+```
+
+**Invalid**:
+
+```yaml
+source:
+  path: "landing/prod/customers"   # raises InvalidValueParameterException (no leading /)
+```
+
+Error message:
+```
+Property 'source.path' (^/[a-zA-Z0-9/$_\.\-]+$) has invalid value 'landing/prod/customers'
+```
+
+---
+
+## Combined with `validset`
+
+`regex` and `validset` can be used together on the same field. Both constraints must pass.
+
+```python
+{
+    "name": "source.format",
+    "validset": ["csv", "json", "parquet"],
+    "regex": r"^[a-z]+$"
+}
+```
+
+---
+
+## Full example
+
+```python
+import yaml
+from pyjeb import control_and_setup
+from pyjeb.exception import InvalidValueParameterException
+
+controls = [
+    { "name": "source", "type": "dict" },
+    { "name": "source.path", "regex": r"^/[a-zA-Z0-9/_\$\.\-]+$" },
+    { "name": "source.format", "validset": ["csv", "json", "parquet"] },
+    { "name": "source.pattern", "default": "*" },
+    { "name": "target", "type": "dict" },
+    { "name": "target.path" },
+    { "name": "target.mode", "default": "append", "validset": ["append", "overwrite"] },
+    { "name": "enabled", "type": "boolean", "default": True },
+    { "name": "max_retries", "type": "integer", "default": 3 },
+    { "name": "threshold", "type": "decimal", "default": 0.95 },
+    { "name": "tags", "type": "list", "default": [] },
+]
+
+job_config = {
+    "source": { "path": "landing/prod/customers", "format": "csv" },
+    "target": { "path": "/bronze/prod/customers" }
+}
+
+try:
+    job = control_and_setup(job_config, controls)
+except InvalidValueParameterException as e:
+    print(e)
+# Property 'source.path' (^/[a-zA-Z0-9/$_\.\-]+$) has invalid value 'landing/prod/customers'
+```

--- a/docs/controls/Types.md
+++ b/docs/controls/Types.md
@@ -1,0 +1,161 @@
+# Controls — Types
+
+PyJeb supports six types for control definitions. The `type` field specifies the expected type of the configuration value. When `type` is omitted, it defaults to `"string"`.
+
+Supported types: `string`, `integer`, `decimal`, `boolean`, `list`, `dict`
+
+---
+
+## `string`
+
+Any scalar value that is not a `dict` or `list`. Numbers and booleans read from YAML or JSON are accepted as-is.
+
+```python
+{ "name": "source.path" }
+{ "name": "source.format", "type": "string", "validset": ["csv", "json", "parquet"] }
+{ "name": "target.mode", "type": "string", "default": "append" }
+```
+
+---
+
+## `integer`
+
+An integer value. Strings like `"3"` or `"-10"` with optional surrounding spaces are accepted and cast to `int`.
+
+```python
+{ "name": "max_retries", "type": "integer", "default": 3 }
+```
+
+| Input | Valid | Output |
+|---|---|---|
+| `3` | Yes | `3` |
+| `"3"` | Yes | `3` |
+| `"-10"` | Yes | `-10` |
+| `"- 10"` | Yes | `-10` |
+| `3.5` | No | — |
+| `"abc"` | No | — |
+
+---
+
+## `decimal`
+
+A floating-point value. Strings with `.` or `,` as decimal separator are accepted and cast to `float`.
+
+```python
+{ "name": "threshold", "type": "decimal", "default": 0.95 }
+```
+
+| Input | Valid | Output |
+|---|---|---|
+| `0.95` | Yes | `0.95` |
+| `"0.95"` | Yes | `0.95` |
+| `"0,95"` | Yes | `0.95` |
+| `"-1.5"` | Yes | `-1.5` |
+| `"abc"` | No | — |
+
+---
+
+## `boolean`
+
+A boolean value. Strings `"true"` and `"false"` (case-insensitive) are accepted and cast to `bool`.
+
+```python
+{ "name": "enabled", "type": "boolean", "default": True }
+```
+
+| Input | Valid | Output |
+|---|---|---|
+| `True` | Yes | `True` |
+| `False` | Yes | `False` |
+| `"true"` | Yes | `True` |
+| `"False"` | Yes | `False` |
+| `1` | No | — |
+
+---
+
+## `list`
+
+A list value. A scalar value (string, number) is automatically wrapped in a single-element list.
+
+```python
+{ "name": "tags", "type": "list", "default": [] }
+```
+
+| Input | Valid | Output |
+|---|---|---|
+| `["crm", "daily"]` | Yes | `["crm", "daily"]` |
+| `"crm"` | Yes | `["crm"]` |
+| `3` | Yes | `[3]` |
+| `{"key": "val"}` | Yes | `[{"key": "val"}]` |
+
+---
+
+## `dict`
+
+A nested dictionary. Used to declare parent fields that contain child controls. Child fields are declared as separate controls using dot notation.
+
+```python
+{ "name": "source", "type": "dict" },
+{ "name": "source.path" },
+{ "name": "source.format", "validset": ["csv", "json", "parquet"] },
+{ "name": "source.pattern", "default": "*" },
+```
+
+No casting is applied for `dict` fields; the value must already be a Python `dict`.
+
+---
+
+## Type summary for the running example
+
+Given this configuration:
+
+```yaml
+ingest_customers:
+  source:
+    path: "/landing/prod/customers/2026-05-11"
+    format: "csv"
+    pattern: "*.csv"
+  target:
+    path: "/bronze/prod/customers"
+    mode: "append"
+  enabled: true
+  max_retries: 3
+  threshold: 0.95
+  tags:
+    - "crm"
+    - "daily"
+```
+
+And these controls:
+
+```python
+controls = [
+    { "name": "source", "type": "dict" },
+    { "name": "source.path" },
+    { "name": "source.format", "validset": ["csv", "json", "parquet"] },
+    { "name": "source.pattern", "default": "*" },
+    { "name": "target", "type": "dict" },
+    { "name": "target.path" },
+    { "name": "target.mode", "default": "append", "validset": ["append", "overwrite"] },
+    { "name": "enabled", "type": "boolean", "default": True },
+    { "name": "max_retries", "type": "integer", "default": 3 },
+    { "name": "threshold", "type": "decimal", "default": 0.95 },
+    { "name": "tags", "type": "list", "default": [] },
+]
+```
+
+After `control_and_setup`, the Python types are:
+
+| Field | Python type |
+|---|---|
+| `source` | `dict` |
+| `source.path` | `str` |
+| `source.format` | `str` |
+| `source.pattern` | `str` |
+| `target` | `dict` |
+| `target.path` | `str` |
+| `target.mode` | `str` |
+| `enabled` | `bool` |
+| `max_retries` | `int` |
+| `threshold` | `float` |
+| `tags` | `list` |

--- a/docs/controls/Validset.md
+++ b/docs/controls/Validset.md
@@ -1,0 +1,110 @@
+# Controls — Validset
+
+The `validset` field restricts a configuration value to a defined set of allowed values. If the value is not in the list, an `InvalidValueParameterException` is raised.
+
+## Syntax
+
+```python
+{ "name": "source.format", "validset": ["csv", "json", "parquet"] }
+```
+
+---
+
+## Static values
+
+The simplest form: a list of exact allowed string values.
+
+```python
+{ "name": "source.format", "validset": ["csv", "json", "parquet"] }
+{ "name": "target.mode", "default": "append", "validset": ["append", "overwrite"] }
+```
+
+**Valid** configuration:
+
+```yaml
+source:
+  format: "csv"     # OK
+target:
+  mode: "append"    # OK
+```
+
+**Invalid** configuration:
+
+```yaml
+source:
+  format: "xml"     # raises InvalidValueParameterException
+```
+
+Error message:
+```
+Property 'source.format' ('csv', 'json', 'parquet') has invalid value 'xml'
+```
+
+---
+
+## Regex patterns in validset
+
+Each entry in `validset` can also be a regex pattern. The value is tested against each entry — first as an exact match, then as a regex.
+
+```python
+{ "name": "source.path", "validset": [r"^/landing/", r"^/bronze/"] }
+```
+
+**Valid**:
+
+```yaml
+source:
+  path: "/landing/prod/customers/2026-05-11"   # matches ^/landing/
+```
+
+**Invalid**:
+
+```yaml
+source:
+  path: "/silver/customers"   # raises InvalidValueParameterException
+```
+
+---
+
+## Combining static values and regex
+
+```python
+{ "name": "source.format", "validset": ["csv", "json", r"^parquet.*$"] }
+```
+
+This allows `"csv"`, `"json"`, or any string starting with `"parquet"` (e.g., `"parquet_snappy"`).
+
+---
+
+## Full example
+
+```python
+import yaml
+from pyjeb import control_and_setup
+from pyjeb.exception import InvalidValueParameterException
+
+controls = [
+    { "name": "source", "type": "dict" },
+    { "name": "source.path" },
+    { "name": "source.format", "validset": ["csv", "json", "parquet"] },
+    { "name": "source.pattern", "default": "*" },
+    { "name": "target", "type": "dict" },
+    { "name": "target.path" },
+    { "name": "target.mode", "default": "append", "validset": ["append", "overwrite"] },
+    { "name": "enabled", "type": "boolean", "default": True },
+    { "name": "max_retries", "type": "integer", "default": 3 },
+    { "name": "threshold", "type": "decimal", "default": 0.95 },
+    { "name": "tags", "type": "list", "default": [] },
+]
+
+job_config = {
+    "source": { "path": "/landing/prod/customers", "format": "xml" },
+    "target": { "path": "/bronze/prod/customers" }
+}
+
+try:
+    job = control_and_setup(job_config, controls)
+except InvalidValueParameterException as e:
+    print(e)
+# Property 'source.format' ('csv', 'json', 'parquet') has invalid value 'xml'
+```

--- a/docs/variables/Custom Functions.md
+++ b/docs/variables/Custom Functions.md
@@ -1,0 +1,135 @@
+# Variables — Custom Functions (`$func`)
+
+Custom functions let you inject computed values into configuration strings at runtime. They are passed as a dictionary of callables to [`control_and_setup`](../api/Control-and-Setup) via the `functions` parameter.
+
+## Syntax
+
+```
+$func.<name>('argument')
+```
+
+The placeholder is replaced by the return value of the function named `<name>`, called with `'argument'` as its sole parameter (always passed as a string).
+
+---
+
+## Passing functions
+
+```python
+functions = {
+    "get_bucket": lambda env: f"s3://my-bucket-{env}"
+}
+
+job = control_and_setup(job_config, controls, functions=functions)
+```
+
+---
+
+## Example
+
+```yaml
+# job.yaml
+ingest_customers:
+  source:
+    path: "/landing/prod/customers/$sys.timestamp('YYYY-MM-DD')"
+    format: "csv"
+  target:
+    path: "$func.get_bucket('prod')/bronze/customers"
+```
+
+```python
+from pyjeb import control_and_setup
+
+controls = [
+    { "name": "source", "type": "dict" },
+    { "name": "source.path" },
+    { "name": "source.format", "validset": ["csv", "json", "parquet"] },
+    { "name": "source.pattern", "default": "*" },
+    { "name": "target", "type": "dict" },
+    { "name": "target.path" },
+    { "name": "target.mode", "default": "append", "validset": ["append", "overwrite"] },
+    { "name": "enabled", "type": "boolean", "default": True },
+    { "name": "max_retries", "type": "integer", "default": 3 },
+    { "name": "threshold", "type": "decimal", "default": 0.95 },
+    { "name": "tags", "type": "list", "default": [] },
+]
+
+functions = {
+    "get_bucket": lambda env: f"s3://my-bucket-{env}"
+}
+
+job_config = {
+    "source": {
+        "path": "/landing/prod/customers/$sys.timestamp('YYYY-MM-DD')",
+        "format": "csv"
+    },
+    "target": { "path": "$func.get_bucket('prod')/bronze/customers" }
+}
+
+job = control_and_setup(job_config, controls, functions=functions, to_object=True)
+print(job.target.path)
+# s3://my-bucket-prod/bronze/customers
+```
+
+---
+
+## Error handling
+
+If a custom function raises an exception, PyJeb wraps it in a `CustomFunctionException`.
+
+```python
+functions = {
+    "get_bucket": lambda env: int(env)   # will fail if env is not a number
+}
+```
+
+```python
+from pyjeb.exception import CustomFunctionException
+
+try:
+    job = control_and_setup(job_config, controls, functions=functions)
+except CustomFunctionException as e:
+    print(e)
+# Function 'func.get_bucket' raise an error with parameter 'prod'
+```
+
+---
+
+## Full example
+
+```python
+import yaml
+from pyjeb import control_and_setup
+
+with open("job.yaml") as f:
+    config = yaml.safe_load(f)
+
+controls = [
+    { "name": "source", "type": "dict" },
+    { "name": "source.path" },
+    { "name": "source.format", "validset": ["csv", "json", "parquet"] },
+    { "name": "source.pattern", "default": "*" },
+    { "name": "target", "type": "dict" },
+    { "name": "target.path" },
+    { "name": "target.mode", "default": "append", "validset": ["append", "overwrite"] },
+    { "name": "enabled", "type": "boolean", "default": True },
+    { "name": "max_retries", "type": "integer", "default": 3 },
+    { "name": "threshold", "type": "decimal", "default": 0.95 },
+    { "name": "tags", "type": "list", "default": [] },
+]
+
+variables = { "env": "prod" }
+
+functions = {
+    "get_bucket": lambda env: f"s3://my-bucket-{env}"
+}
+
+for job_name, job_config in config.items():
+    job = control_and_setup(
+        job_config,
+        controls,
+        variables=variables,
+        functions=functions,
+        to_object=True
+    )
+    print(f"{job_name}: {job.target.path}")
+```

--- a/docs/variables/Overview.md
+++ b/docs/variables/Overview.md
@@ -1,0 +1,54 @@
+# Variables — Overview
+
+PyJeb supports a variable system that injects dynamic values into configuration strings at runtime. Variable placeholders are embedded directly in configuration values and resolved during the [`control_and_setup`](../api/Control-and-Setup) call.
+
+## Variable modes
+
+| Mode | Placeholder syntax | Source |
+|---|---|---|
+| `sys` | `$sys.<name>` or `$sys.<name>('format')` | Built-in system values |
+| `var` | `$var.<name>` | User-supplied dictionary |
+| `func` | `$func.<name>('argument')` | User-supplied callable |
+
+---
+
+## How placeholders work
+
+Placeholders embedded in a configuration string are replaced by the corresponding value at runtime:
+
+```yaml
+source:
+  path: "/landing/$var.env/customers/$sys.timestamp('YYYY-MM-DD')"
+```
+
+With `variables = { "env": "prod" }` and today's date `2026-05-11`, the resolved value is:
+
+```
+/landing/prod/customers/2026-05-11
+```
+
+Multiple placeholders can appear in the same value.
+
+---
+
+## Passing variables and functions
+
+```python
+from pyjeb import control_and_setup
+
+variables = { "env": "prod" }
+
+functions = {
+    "get_bucket": lambda env: f"s3://my-bucket-{env}"
+}
+
+job = control_and_setup(job_config, controls, variables=variables, functions=functions)
+```
+
+---
+
+## Pages
+
+- [`$sys` — System variables](sys-variables): `$sys.timestamp`, `$sys.date`
+- [`$var` — User variables](user-variables): `$var.<name>`
+- [`$func` — Custom functions](custom-functions): `$func.<name>('argument')`

--- a/docs/variables/Sys Variables.md
+++ b/docs/variables/Sys Variables.md
@@ -1,0 +1,83 @@
+# Variables — System Variables (`$sys`)
+
+System variables are built-in dynamic values provided by PyJeb. They require no configuration and are resolved automatically at runtime.
+
+## Available variables
+
+| Variable | Description | Default format |
+|---|---|---|
+| `$sys.timestamp` | Current date and time | `YYYYMMDDHHMMSS` |
+| `$sys.timestamp('format')` | Current date and time with a custom format | Custom |
+| `$sys.date` | Current date | `YYYYMMDD` |
+| `$sys.date('format')` | Current date with a custom format | Custom |
+
+---
+
+## Format tokens
+
+| Token | Meaning | Example |
+|---|---|---|
+| `YYYY` | 4-digit year | `2026` |
+| `MM` | 2-digit month | `05` |
+| `DD` | 2-digit day | `11` |
+| `hh` | 2-digit hour (24h) | `14` |
+| `mm` | 2-digit minute | `30` |
+| `ss` | 2-digit second | `00` |
+
+---
+
+## Format examples
+
+| Placeholder | Output (2026-05-11 14:30:00) |
+|---|---|
+| `$sys.timestamp` | `20260511143000` |
+| `$sys.timestamp('YYYY-MM-DD')` | `2026-05-11` |
+| `$sys.timestamp('YYYY/MM/DD hh:mm:ss')` | `2026/05/11 14:30:00` |
+| `$sys.date` | `20260511` |
+| `$sys.date('YYYY-MM-DD')` | `2026-05-11` |
+
+---
+
+## Example
+
+Use `$sys.timestamp` to build a dated source path:
+
+```yaml
+# job.yaml
+ingest_customers:
+  source:
+    path: "/landing/prod/customers/$sys.timestamp('YYYY-MM-DD')"
+    format: "csv"
+  target:
+    path: "/bronze/prod/customers"
+```
+
+```python
+from pyjeb import control_and_setup
+
+controls = [
+    { "name": "source", "type": "dict" },
+    { "name": "source.path" },
+    { "name": "source.format", "validset": ["csv", "json", "parquet"] },
+    { "name": "source.pattern", "default": "*" },
+    { "name": "target", "type": "dict" },
+    { "name": "target.path" },
+    { "name": "target.mode", "default": "append", "validset": ["append", "overwrite"] },
+    { "name": "enabled", "type": "boolean", "default": True },
+    { "name": "max_retries", "type": "integer", "default": 3 },
+    { "name": "threshold", "type": "decimal", "default": 0.95 },
+    { "name": "tags", "type": "list", "default": [] },
+]
+
+job_config = {
+    "source": {
+        "path": "/landing/prod/customers/$sys.timestamp('YYYY-MM-DD')",
+        "format": "csv"
+    },
+    "target": { "path": "/bronze/prod/customers" }
+}
+
+job = control_and_setup(job_config, controls, to_object=True)
+print(job.source.path)
+# /landing/prod/customers/2026-05-11
+```

--- a/docs/variables/User Variables.md
+++ b/docs/variables/User Variables.md
@@ -1,0 +1,132 @@
+# Variables — User Variables (`$var`)
+
+User variables let you inject custom named values into configuration strings at runtime. They are passed as a dictionary to [`control_and_setup`](../api/Control-and-Setup) via the `variables` parameter.
+
+## Syntax
+
+```
+$var.<name>
+```
+
+The placeholder is replaced by the value in the `variables` dictionary whose key matches `<name>`.
+
+---
+
+## Passing variables
+
+```python
+variables = { "env": "prod" }
+
+job = control_and_setup(job_config, controls, variables=variables)
+```
+
+---
+
+## Example
+
+```yaml
+# job.yaml
+ingest_customers:
+  source:
+    path: "/landing/$var.env/customers/$sys.timestamp('YYYY-MM-DD')"
+    format: "csv"
+  target:
+    path: "/bronze/$var.env/customers"
+```
+
+```python
+from pyjeb import control_and_setup
+
+controls = [
+    { "name": "source", "type": "dict" },
+    { "name": "source.path" },
+    { "name": "source.format", "validset": ["csv", "json", "parquet"] },
+    { "name": "source.pattern", "default": "*" },
+    { "name": "target", "type": "dict" },
+    { "name": "target.path" },
+    { "name": "target.mode", "default": "append", "validset": ["append", "overwrite"] },
+    { "name": "enabled", "type": "boolean", "default": True },
+    { "name": "max_retries", "type": "integer", "default": 3 },
+    { "name": "threshold", "type": "decimal", "default": 0.95 },
+    { "name": "tags", "type": "list", "default": [] },
+]
+
+variables = { "env": "prod" }
+
+job_config = {
+    "source": {
+        "path": "/landing/$var.env/customers/$sys.timestamp('YYYY-MM-DD')",
+        "format": "csv"
+    },
+    "target": { "path": "/bronze/$var.env/customers" }
+}
+
+job = control_and_setup(job_config, controls, variables=variables, to_object=True)
+print(job.source.path)    # /landing/prod/customers/2026-05-11
+print(job.target.path)    # /bronze/prod/customers
+```
+
+---
+
+## Multiple variables
+
+```python
+variables = {
+    "env": "prod",
+    "region": "eu-west-1"
+}
+```
+
+```yaml
+source:
+  path: "/landing/$var.env/$var.region/customers/$sys.timestamp('YYYY-MM-DD')"
+```
+
+Resolves to:
+
+```
+/landing/prod/eu-west-1/customers/2026-05-11
+```
+
+---
+
+## Unresolved variables
+
+If a variable name is not found in the `variables` dictionary, the placeholder is left as-is in the string. No error is raised.
+
+```python
+variables = {}  # env not defined
+# result: "/landing/$var.env/customers/2026-05-11"  — $var.env is not replaced
+```
+
+---
+
+## Full example
+
+```python
+import yaml
+from pyjeb import control_and_setup
+
+with open("job.yaml") as f:
+    config = yaml.safe_load(f)
+
+controls = [
+    { "name": "source", "type": "dict" },
+    { "name": "source.path" },
+    { "name": "source.format", "validset": ["csv", "json", "parquet"] },
+    { "name": "source.pattern", "default": "*" },
+    { "name": "target", "type": "dict" },
+    { "name": "target.path" },
+    { "name": "target.mode", "default": "append", "validset": ["append", "overwrite"] },
+    { "name": "enabled", "type": "boolean", "default": True },
+    { "name": "max_retries", "type": "integer", "default": 3 },
+    { "name": "threshold", "type": "decimal", "default": 0.95 },
+    { "name": "tags", "type": "list", "default": [] },
+]
+
+variables = { "env": "prod" }
+
+for job_name, job_config in config.items():
+    job = control_and_setup(job_config, controls, variables=variables, to_object=True)
+    print(f"{job_name}: {job.source.path} → {job.target.path}")
+```


### PR DESCRIPTION
# PR: Enhance documentation structure and sync with wiki

## Description

This PR initializes the documentation folder and sets up the automated sync to the GitHub Wiki.

## Changes

- **`docs: update README with new example and wiki link`** (`9c42850`)
  Update the README to include a new usage example and a reference link to the wiki.

- **`docs: init docs folder with wiki-compatible structure`** (`ae8203f`)
  Create the `docs/` folder with wiki-compatible markdown files (`index.md`, `getting-started.md`, `exceptions.md`).

- **`ci: add workflow to sync docs folder to wiki`** (`1ca704e`)
  Add a GitHub Actions workflow that automatically syncs the `docs/` folder to the repository wiki on every push to `main`.