### PR TITLE
fix(controls): resolve conditional default checks to accept types other than string

### DIFF
--- a/src/pyjeb/controls.py
+++ b/src/pyjeb/controls.py
@@ -63,6 +63,7 @@ def get_controls_of_controls():
             "type": "string",
             "default" : None,
             "expressions": [],
+            "nocheck" : True,
         },
         {
             "name": "if.validset",

--- a/src/pyjeb/main.py
+++ b/src/pyjeb/main.py
@@ -65,13 +65,13 @@ def internal_control_and_setup_dict(configuration, control, variables, functions
                 value = apply_boolean_expression(condition["expression"], configuration)
 
                 if value.lower() == "true":
-                    if condition["default"] is not None:
-                        configuration[current_name] = condition["default"]
-                    if condition["validset"] is not None:
+                    if "default" in condition.keys():
+                        current_control["default"] = condition["default"]
+                    if "validset" in condition.keys() and condition["validset"] is not None:
                         current_control["validset"] = condition["validset"]
-                    if condition["regex"] is not None:
+                    if "regex" in condition.keys() and condition["regex"] is not None:
                         current_control["regex"] = condition["regex"]
-                    if condition["type"] is not None:
+                    if "type" in condition.keys() and condition["type"] is not None:
                         current_control["type"] = condition["type"]
 
         # check if all target keys are setup and setup default values

--- a/tests/test_config_success.py
+++ b/tests/test_config_success.py
@@ -217,3 +217,80 @@ def test_configuration_conditional_controls_success():
     assert isinstance(config_success["fields"][1]["format_default"], str)
     assert isinstance(config_success["fields"][2]["format_default"], str)
     assert isinstance(config_success["fields"][3]["format_default"], str)
+
+
+def test_if_default_string():
+    """`if.default` assigns a string default when condition matches."""
+
+    controls = [
+        {"name": "items", "type": "list", "default": []},
+        {"name": "items.value", "type": "string"},
+        {
+            "name": "items.extra",
+            "type": "string",
+            "if": [
+                {"expression": "value == 'use_string'", "default": "a_string"}
+            ],
+        },
+    ]
+
+    configuration = {"items": [{"value": "use_string"}]}
+    result = control_and_setup(configuration, controls)
+    assert result["items"][0]["extra"] == "a_string"
+
+def test_if_default_list():
+    """`if.default` assigns a list default when condition matches."""
+
+    controls = [
+        {"name": "items", "type": "list", "default": []},
+        {"name": "items.value", "type": "string"},
+        {
+            "name": "items.extra",
+            "type": "list",
+            "if": [
+                {"expression": "value == 'use_list'", "default": ["one", "two"]}
+            ],
+        },
+    ]
+
+    configuration = {"items": [{"value": "use_list"}]}
+    result = control_and_setup(configuration, controls)
+    assert result["items"][0]["extra"] == ["one", "two"]
+
+def test_if_default_none():
+    """`if.default` assigns None when condition matches."""
+
+    controls = [
+        {"name": "items", "type": "list", "default": []},
+        {"name": "items.value", "type": "string"},
+        {
+            "name": "items.extra",
+            "type": "string",
+            "if": [
+                {"expression": "value == 'use_none'", "default": None}
+            ],
+        },
+    ]
+
+    configuration = {"items": [{"value": "use_none"}]}
+    result = control_and_setup(configuration, controls)
+    assert result["items"][0]["extra"] is None
+
+def test_if_default_dict():
+    """`if.default` assigns a dict default when condition matches."""
+
+    controls = [
+        {"name": "items", "type": "list", "default": []},
+        {"name": "items.value", "type": "string"},
+        {
+            "name": "items.extra",
+            "type": "dict",
+            "if": [
+                {"expression": "value == 'use_dict'", "default": {"k": "v"}}
+            ],
+        },
+    ]
+
+    configuration = {"items": [{"value": "use_dict"}]}
+    result = control_and_setup(configuration, controls, variables, functions)
+    assert result["items"][0]["extra"] == {"k": "v"}


### PR DESCRIPTION
**Summary:**
- Fixes conditional defaults so `if.default` now works for non-string default values.
- Ensures list, dict, and explicit None defaults are applied when the condition matches.
- Adds coverage for these cases to prevent regressions.